### PR TITLE
Accept wider version range for typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-typer = "^0.9.0"
+typer = ">=0.9.0, <1"
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
@BSpendlove: Thanks for sharing your package!

Previously, the version range for typer was set to `^0.9.0`. This is very limiting, because according to https://devhints.io/semver, this means `>= 0.9.0, < 0.10.0`.

In particular, I wanted to use this package with typer 0.15.0, but couldn't install it until I cloned the repo and made this change.

This commit changes the version range to `>=0.9.0, <1` to allow for wider compatibility with current and future versions of typer.

I am using this with typer 0.15.0 and it works great for me.